### PR TITLE
Add and enable DeleteOnScan

### DIFF
--- a/Jellyfin.Plugin.ChapterSegments/ChapterMediaSegmentProvider.cs
+++ b/Jellyfin.Plugin.ChapterSegments/ChapterMediaSegmentProvider.cs
@@ -34,6 +34,9 @@ public class ChapterMediaSegmentProvider : IMediaSegmentProvider
     public string Name => "Chapter Segments Provider";
 
     /// <inheritdoc />
+    public ValueTask<bool> DeleteOnScan => new(true);
+
+    /// <inheritdoc />
     public ValueTask<bool> Supports(BaseItem item) => new(item is IHasMediaSources);
 
     private MediaSegmentType? GetMediaSegmentType(string name)


### PR DESCRIPTION
Add DeleteOnScan and set it to true, meaning that all media segments will be re-generated on each scan so that regex changes in the config will be taken into account and wrong media segments can be corrected

**Depends on** [#14218](https://github.com/jellyfin/jellyfin/pull/14218) in the jellyfin repo to be merged.

Related issue in the jellyfin repo: [#14117](https://github.com/jellyfin/jellyfin/issues/14117)